### PR TITLE
templates: Reduce number of shards to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,21 @@ changelog: git_chglog_check
 
 CONCOURSE_PIPELINE := go-elasticsearch-alerts
 
+
 check_fly:
-	if [ -z "$(FLY)" ]; then \
-		sudo mkdir -p /usr/local/bin; \
-		sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux"; \
-		sudo chmod +x /usr/local/bin/fly; \
-		/usr/local/bin/fly --version; \
-	fi
+ifeq ($(FLY),)
+	sudo mkdir -p /usr/local/bin
+	sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux"; \
+	sudo chmod +x /usr/local/bin/fly
+	/usr/local/bin/fly --version
+endif
 .PHONY: check_fly
 
 
 set_pipeline: check_fly
 	$(FLY) --target mci-ci-oss validate-pipeline \
-		--config ci/pipeline.yml
+		--config ci/pipeline.yml \
+		--strict
 
 	$(FLY) --target mci-ci-oss set-pipeline \
 		--config ci/pipeline.yml \

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ CONCOURSE_PIPELINE := go-elasticsearch-alerts
 check_fly:
 ifeq ($(FLY),)
 	sudo mkdir -p /usr/local/bin
-	sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux"; \
+	sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux";
 	sudo chmod +x /usr/local/bin/fly
 	/usr/local/bin/fly --version
 endif

--- a/ci/build-release.sh
+++ b/ci/build-release.sh
@@ -19,7 +19,7 @@ readonly GORELEASER_VERSION=v0.104.0
 
 echo "==> Installing APK dependencies"
 
-apk add -qU --no-progress \
+apk add -qU --no-cache --no-progress \
   make \
   bash \
   git \

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,13 +6,12 @@
 # ====================================
 resource_types:
 - name: slack-alert
-  type: docker-image
+  type: registry-image
   source:
     repository: arbourd/concourse-slack-alert-resource
-    channel: '#build'
 
 - name: pull-request
-  type: docker-image
+  type: registry-image
   source:
     repository: teliaoss/github-pr-resource
 
@@ -39,7 +38,7 @@ resources:
     tag_filter: 'v*'
 
 - name: golang
-  type: docker-image
+  type: registry-image
   source:
     repository: golang
     tag: 1.11.4-alpine3.8
@@ -77,21 +76,18 @@ jobs:
         path: test-pull-request
         status: success
         context: $BUILD_JOB_NAME
-        comment: test-pull-request/ci/pr_test_success
     on_failure:
       put: test-pull-request
       params:
         path: test-pull-request
         status: failure
         context: $BUILD_JOB_NAME
-        comment: test-pull-request/ci/pr_test_failure
     on_abort:
       put: test-pull-request
       params:
         path: test-pull-request
         status: error
         context: $BUILD_JOB_NAME
-        comment: test-pull-request/ci/pr_test_failure
 
 - name: build-release
   serial: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -75,19 +75,19 @@ jobs:
       params:
         path: test-pull-request
         status: success
-        context: $BUILD_JOB_NAME
+        context: test-pr
     on_failure:
       put: test-pull-request
       params:
         path: test-pull-request
         status: failure
-        context: $BUILD_JOB_NAME
+        context: test-pr
     on_abort:
       put: test-pull-request
       params:
         path: test-pull-request
         status: error
-        context: $BUILD_JOB_NAME
+        context: test-pr
 
 - name: build-release
   serial: true

--- a/ci/pr_test_failure
+++ b/ci/pr_test_failure
@@ -1,2 +1,0 @@
-### Concourse CI
-Tests failing :x:

--- a/ci/pr_test_success
+++ b/ci/pr_test_success
@@ -1,2 +1,0 @@
-### Concourse CI
-All tests passing :white_check_mark:

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -14,13 +14,16 @@
 
 set -e
 
-PROJECT="github.com/morningconsult/go-elasticsearch-alerts"
+readonly PROJECT="github.com/morningconsult/go-elasticsearch-alerts"
 
 # NOTE: This script is intended to be run in a
 #   golang:1.11.3-alpine3.8 Docker container
 
 # Install dependencies
-apk add -qU --no-cache make git bzr
+apk add -qU --no-cache --no-progress \
+  make \
+  git \
+  bzr
 
 # Run tests
 CGO_ENABLED=0 make test

--- a/command/query/job.go
+++ b/command/query/job.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	templateVersion        string = "0.0.1"
+	templateVersion        string = "0.0.2"
 	defaultStateIndexAlias string = "go-es-alerts"
 	defaultTimestampFormat string = time.RFC3339
 	defaultBodyField       string = "hits.hits._source"
@@ -272,7 +272,7 @@ func (q *QueryHandler) Run(ctx context.Context, outputCh chan *alert.Alert, wg *
 // will be named 'go-es-alerts-status-{date}'; therefore, this template
 // enables searching all state indices via this alias
 func (q *QueryHandler) PutTemplate(ctx context.Context) error {
-	payload := fmt.Sprintf(`{"index_patterns":["%s-status-%s-*"],"order":0,"aliases":{%q:{}},"settings":{"index":{"number_of_shards":5,"number_of_replicas":1,"auto_expand_replicas":"0-2","translog":{"flush_threshold_size":"752mb"},"sort":{"field":["next_query","rule_name","hostname"],"order":["desc","desc","desc"]}}},"mappings":{"_doc":{"dynamic_templates":[{"strings_as_keywords":{"match_mapping_type":"string","mapping":{"type":"keyword"}}}],"properties":{"@timestamp":{"type":"date"},"rule_name":{"type":"keyword"},"next_query":{"type":"date"},"hostname":{"type":"keyword"},"hits_count":{"type":"long","null_value":0},"hits":{"enabled":false}}}}}`, defaultStateIndexAlias, templateVersion, q.TemplateName())
+	payload := fmt.Sprintf(`{"index_patterns":["%s-status-%s-*"],"order":0,"aliases":{%q:{}},"settings":{"index":{"number_of_shards":1,"number_of_replicas":1,"auto_expand_replicas":"0-3","codec":"best_compression","translog":{"flush_threshold_size":"752mb"},"sort":{"field":["next_query","rule_name","hostname"],"order":["desc","desc","desc"]}}},"mappings":{"_doc":{"dynamic_templates":[{"strings_as_keywords":{"match_mapping_type":"string","mapping":{"type":"keyword"}}}],"properties":{"@timestamp":{"type":"date"},"rule_name":{"type":"keyword"},"next_query":{"type":"date"},"hostname":{"type":"keyword"},"hits_count":{"type":"long","null_value":0},"hits":{"enabled":false}}}}}`, defaultStateIndexAlias, templateVersion, q.TemplateName())
 
 	resp, err := q.makeRequest(ctx, "PUT", fmt.Sprintf("%s/_template/%s", q.esURL, q.TemplateName()), []byte(payload))
 	if err != nil {


### PR DESCRIPTION
Elasticsearch is changing [the default number of shards](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_index_creation_no_longer_defaults_to_five_shards) for all indices from 5 to 1, since 5 is pretty unnecessary. Reducing the number of shards will reduce load on Elasticsearch clusters, and since this creates daily indicies, that can be substantial.

Changes:

- This PR reduces the default number of shards for the writeback index to 1. 
- Since the template settings change in this PR I updated the version on the index to 0.0.2 also.
- Cleaned up a number of things in CI pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.