### PR TITLE
Update deprecated field in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
       - windows
       - darwin
       - linux
-archive:
+archives:
   name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
   replacements:
     darwin: Darwin


### PR DESCRIPTION
*Description of changes:*
Per the [goreleaser docs](https://goreleaser.com/deprecations/#archive) the `archive` field of the `.goreleaser.yml` should be switched to `archives`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.