### PR TITLE
Fix bad .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,17 @@ builds:
       - darwin
       - linux
 archives:
-  name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  format_overrides:
-    - goos: windows
-      format: zip
+  - id: main
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
*Description of changes:*
Incorrectly updated `.goreleaser.yml` file in https://github.com/morningconsult/go-elasticsearch-alerts/pull/22. This PR should correct the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.