### PR TITLE
command(template): Update index template creation for es7 deprecations

### DIFF
--- a/command/query/job.go
+++ b/command/query/job.go
@@ -306,7 +306,7 @@ func (q *QueryHandler) PutTemplate(ctx context.Context) error {
     "index": {
       "number_of_shards": 1,
       "number_of_replicas": 1,
-      "auto_expand_replicas": "0-3",
+      "auto_expand_replicas": "0-2",
       "codec": "best_compression",
       "translog": {
 	"flush_threshold_size": "752mb"
@@ -357,7 +357,7 @@ func (q *QueryHandler) PutTemplate(ctx context.Context) error {
 	resp, err := q.makeRequest(
 		ctx,
 		http.MethodPut,
-		fmt.Sprintf("%s/_template/%s", q.esURL, q.TemplateName()),
+		fmt.Sprintf("%s/_template/%s?include_type_name=true", q.esURL, q.TemplateName()),
 		bytes.NewBufferString(payload),
 	)
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*

This PR updates the request to set the index template in Elasticsearch to use the [`include_type_name`](https://www.elastic.co/guide/en/elasticsearch/reference/7.1/removal-of-types.html#_schedule_for_removal_of_mapping_types) query parameter to comply with pending deprecation of mapping types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.