### PR TITLE
Update References from master to main

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -3,7 +3,7 @@ name: Bump
 on:
   push:
     branches:
-      - master
+      - main
     tags-ignore:
       - v*
     paths-ignore:
@@ -68,7 +68,7 @@ jobs:
         git tag "v${VERSION}"
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@main
       with:
         github_token: ${{ secrets.PUBLISH_TOKEN }}
         tags: true

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -68,7 +68,7 @@ jobs:
         git tag "v${VERSION}"
 
     - name: Push changes
-      uses: ad-m/github-push-action@main
+      uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.PUBLISH_TOKEN }}
         tags: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
     tags-ignore:
       - v*
     paths-ignore:
@@ -11,7 +11,7 @@ on:
       - CHANGELOG.md
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ When filing an issue, please check [existing open](https://github.com/morningcon
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -44,6 +44,6 @@ Looking at the existing issues is a great way to find something to contribute on
 
 ## Licensing
 
-See the [LICENSE](https://github.com/morningconsult/go-elasticsearch-alerts/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/morningconsult/go-elasticsearch-alerts/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/ci/release/version.py
+++ b/ci/release/version.py
@@ -21,7 +21,7 @@ def get_latest_version(repo):
 
     return semvers[0]
 
-def next_version(latest_tag, version, repo, branch='master'):
+def next_version(latest_tag, version, repo, branch='main'):
     latest_tagged_commit = repo.commit(latest_tag)
 
     pre_v1 = version.major < 1


### PR DESCRIPTION
This PR was created to update all references from 'master' to 'main' in this repo.<br /><br />The following paths have been excluded: '[CHANGELOG.md docs/ examples/ .git/ go.mod go.sum]'<br /><br />**NOTE**: This PR was generated automatically. Please take a close look before approving and merging!