### PR TITLE
chore: Update bump and test workflows for latest versions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -12,18 +12,11 @@ on:
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
-      image: python:3.7.3
+      image: python:3.9.6
 
     steps:
-    - name: Install git
-      run: |
-        echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list
-        apt-get -yqq update
-        apt-get -yqq install git
-        apt-get clean all
-
     - uses: actions/checkout@v2
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.8
+        go-version: 1.16.7
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ on:
 jobs:
   test:
     name: Run linting and tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: golang:1.15.8-alpine3.13
+      image: golang:1.16.7-alpine3.14
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -28,11 +28,11 @@ jobs:
         CGO_ENABLED: '0'
       run: |
         apk add -qU --no-cache --no-progress curl git
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin "v1.36.0"
-        golangci-lint run ./...
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin "v1.40.1"
+        golangci-lint run
 
     - name: Run tests
       env:
         CGO_ENABLED: '0'
         GO111MODULE: 'on'
-      run: go test ./...
+      run: go test -cover ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.15.8-alpine3.13
+FROM golang:1.16.7-alpine3.14
 
 RUN set -e; \
   apk add -qU --no-cache git make bzr; \

--- a/command/alert/alert_test.go
+++ b/command/alert/alert_test.go
@@ -45,7 +45,7 @@ type fileAlertMethod struct {
 }
 
 func (f *fileAlertMethod) Write(ctx context.Context, rule string, records []*Record) error {
-	outfile, err := os.OpenFile(f.outputFilepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	outfile, err := os.OpenFile(f.outputFilepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return xerrors.Errorf("error opening new file: %v", err)
 	}

--- a/command/alert/file/file.go
+++ b/command/alert/file/file.go
@@ -78,7 +78,7 @@ func validateConfig(config *AlertMethodConfig) error {
 // If there was an error writing logs to disk, it returns a
 // non-nil error.
 func (f *AlertMethod) Write(ctx context.Context, rule string, records []*alert.Record) error {
-	outfile, err := os.OpenFile(f.outputFilepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	outfile, err := os.OpenFile(f.outputFilepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return xerrors.Errorf("error opening new file: %v", err)
 	}

--- a/command/handlers.go
+++ b/command/handlers.go
@@ -78,7 +78,7 @@ func buildQueryHandlers(
 	return queryHandlers, nil
 }
 
-func buildMethod(output config.OutputConfig) (alert.Method, error) { // nolint: gocyclo
+func buildMethod(output config.OutputConfig) (alert.Method, error) {
 	var method alert.Method
 	var err error
 

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -134,7 +134,7 @@ func TestParseConfig_MainConfig(t *testing.T) {
 			}
 
 			if tc.name != "homedir-error" && tc.name != "file-doesnt-exist" {
-				if err := ioutil.WriteFile(tc.path, []byte(tc.data), 0666); err != nil {
+				if err := ioutil.WriteFile(tc.path, []byte(tc.data), 0o666); err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(tc.path)
@@ -555,7 +555,7 @@ func TestParseConfig_Rules(t *testing.T) {
 
 			for _, file := range tc.files {
 				fname := filepath.Join(tc.path, file.filename)
-				if err := ioutil.WriteFile(fname, []byte(file.data), 0666); err != nil {
+				if err := ioutil.WriteFile(fname, []byte(file.data), 0o666); err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(fname)


### PR DESCRIPTION
This updates the test, bump, and release workflows with go 1.16.7
and newer versions of python/ubuntu to fix the broken bump and
release stages.

Signed-off-by: Alex Dulin <alex@morningconsult.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.