### PR TITLE
feat: support compatibility with elasticsearch 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         CGO_ENABLED: '0'
       run: |
         apk add -qU --no-cache --no-progress curl git
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin "v1.40.1"
+        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "v1.40.1"
         golangci-lint run
 
     - name: Run tests

--- a/examples/start-test-system.sh
+++ b/examples/start-test-system.sh
@@ -49,7 +49,7 @@ done
 echo "==> Elasticsearch is healthy. Creating index \"${INDEX}\"..."
 
 ## Create the test index
-curl "${ES_URL}/${INDEX}?include_type_name=true" \
+curl "${ES_URL}/${INDEX}" \
   -s \
   -H "Content-Type: application/json" \
   -X PUT \
@@ -62,7 +62,7 @@ curl "${ES_URL}/${INDEX}?include_type_name=true" \
         "properties": {
           "@timestamp": { "type": "date" },
           "source": { "type": "keyword" },
-          "system": { 
+          "system": {
             "properties": {
               "syslog": {
                 "properties": {


### PR DESCRIPTION
This enables compatibility with Elasticsearch version 8. It removes deprecated and removed paramter usage, and includes REST API compatibility headers for future changes.

Signed-off-by: Alex Dulin <alex@morningconsult.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.