### PR TITLE
Fix segfault when attempting to open rule file without read permissions

### DIFF
--- a/config/parse.go
+++ b/config/parse.go
@@ -292,7 +292,7 @@ func ParseRules() ([]RuleConfig, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, xerrors.Errorf("error opening file %s: %v", file.Name(), err)
+			return nil, xerrors.Errorf("error opening file: %v", err)
 		}
 
 		dec := json.NewDecoder(file)


### PR DESCRIPTION
morningconsult/go-elasticsearch-alerts#124

*Description of changes:*
Remove reference to invalid file pointer in error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.