### PR TITLE
ci: use default github.token for bumps

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
       image: python:3.9.6
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
@@ -63,5 +63,4 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.PUBLISH_TOKEN }}
         tags: true


### PR DESCRIPTION
I was getting a 401 on bump, which means there might be something wrong with the credentials we were previously trying to use. But it appears the token that the github-push-action opts into by default should already have permissions to do this, according to how our repo is configured. So let's give that a go instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.