### PR TITLE
ci: swap back to personal access token

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -63,4 +63,5 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
+        github_token: ${{ secrets.PUBLISH_TOKEN }}
         tags: true


### PR DESCRIPTION
My new theory is that the issue was that the maintainers group (which includes Dilan, the owner of the PAT used) was only granted "write" access, but needed "maintain" access. This is how
morningconsult/docker-credential-vault-login was functional, because in that repo Dilan was explicitly a maintainer.

So I have tweaked the settings and am now re-applying his token, which I now believe is necessary based on the `github-push-action` docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.