### PR TITLE
refactor: address golangci-lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,6 +41,10 @@ linters:
         - fmt.Fprint(net/http.ResponseWriter)
         - fmt.Fprintf(net/http.ResponseWriter)
         - fmt.Fprintln(net/http.ResponseWriter)
+        - os.Setenv
+        - os.Unsetenv
+        - os.Remove
+        - (*github.com/hashicorp/consul/api.Lock).Unlock
 
         # Handled by errchkjson
         - encoding/json.Marshal
@@ -76,6 +80,8 @@ linters:
       - linters: [revive]
         path: _test\.go
         text: unused-parameter
+      - linters: [revive]
+        text: package-comments
 
       # Duplicates of errcheck
       - linters: [gosec]

--- a/ci/lint/errcheck-exclude.txt
+++ b/ci/lint/errcheck-exclude.txt
@@ -1,7 +1,0 @@
-(io.Closer).Close
-(net/http.ResponseWriter).Write
-os.Setenv
-os.Unsetenv
-os.Remove
-(*github.com/hashicorp/consul/api.Lock).Unlock
-(*os.File).Close

--- a/command/alert/alert.go
+++ b/command/alert/alert.go
@@ -112,7 +112,7 @@ type Handler struct {
 func NewHandler(config *HandlerConfig) *Handler {
 	return &Handler{
 		logger: config.Logger,
-		rand:   rand.New(rand.NewSource(int64(time.Now().Nanosecond()))), // nolint: gosec
+		rand:   rand.New(rand.NewSource(int64(time.Now().Nanosecond()))), //nolint:gosec
 		StopCh: make(chan struct{}),
 		DoneCh: make(chan struct{}),
 	}
@@ -128,7 +128,7 @@ func NewHandler(config *HandlerConfig) *Handler {
 // ctx.Done() or StopCh becomes unblocked. Before returning,
 // it will close the DoneCh. Once DoneCh is closed, Run
 // should not be called again.
-func (a *Handler) Run(ctx context.Context, outputCh <-chan *Alert) { // nolint: gocyclo
+func (a *Handler) Run(ctx context.Context, outputCh <-chan *Alert) { //nolint:gocyclo,gocognit
 	defer func() {
 		close(a.DoneCh)
 	}()

--- a/command/alert/alert_test.go
+++ b/command/alert/alert_test.go
@@ -70,7 +70,7 @@ func (e *errorAlertMethod) Write(ctx context.Context, rule string, records []*Re
 func TestRun(t *testing.T) {
 	outputCh := make(chan *Alert, 1)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 
 	ah := NewHandler(&HandlerConfig{
 		Logger: hclog.NewNullLogger(),
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 func TestRunError(t *testing.T) {
 	outputCh := make(chan *Alert, 1)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 
 	buf := new(bytes.Buffer)
 	logger := hclog.New(&hclog.LoggerOptions{

--- a/command/alert/email/email.go
+++ b/command/alert/email/email.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"golang.org/x/xerrors"
+
+	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 )
 
 const (
@@ -127,7 +128,7 @@ func (e *AlertMethod) Write(ctx context.Context, rule string, records []*alert.R
 
 // buildMessage creates an email message from the provided
 // records. It will return a non-nil error if an error occurs.
-func (e *AlertMethod) buildMessage(rule string, records []*alert.Record) (string, error) { // nolint: funlen
+func (e *AlertMethod) buildMessage(rule string, records []*alert.Record) (string, error) {
 	alert := struct {
 		Name    string
 		Records []*alert.Record
@@ -138,8 +139,8 @@ func (e *AlertMethod) buildMessage(rule string, records []*alert.Record) (string
 
 	funcs := template.FuncMap{
 		"tabsAndLines": func(text string) template.HTML {
-			escaped := strings.Replace(template.HTMLEscapeString(text), "\n", "<br>", -1)
-			return template.HTML(strings.Replace(escaped, " ", "&nbsp;", -1)) // nolint: gosec
+			escaped := strings.ReplaceAll(template.HTMLEscapeString(text), "\n", "<br>")
+			return template.HTML(strings.ReplaceAll(escaped, " ", "&nbsp;")) //nolint:gosec
 		},
 	}
 

--- a/command/alert/email/email_test.go
+++ b/command/alert/email/email_test.go
@@ -15,7 +15,6 @@ package email
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
@@ -82,11 +81,9 @@ func TestNewAlertMethod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			switch tc.name {
 			case "password-set-in-env":
-				os.Setenv(EnvEmailAuthPassword, "random-password")
-				defer os.Unsetenv(EnvEmailAuthPassword)
+				t.Setenv(EnvEmailAuthPassword, "random-password")
 			case "username-set-in-env":
-				os.Setenv(EnvEmailAuthUsername, "test@gmail.com")
-				defer os.Unsetenv(EnvEmailAuthUsername)
+				t.Setenv(EnvEmailAuthUsername, "test@gmail.com")
 			default:
 			}
 			_, err := NewAlertMethod(tc.config)

--- a/command/alert/file/file.go
+++ b/command/alert/file/file.go
@@ -21,8 +21,9 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"golang.org/x/xerrors"
+
+	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 )
 
 // Ensure AlertMethod adheres to the alert.Method interface.

--- a/command/alert/file/file_test.go
+++ b/command/alert/file/file_test.go
@@ -108,7 +108,7 @@ func TestWrite(t *testing.T) {
 					Text:   "{\n    \"ayy\": \"lmao\"\n}",
 				},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			err = f.Write(ctx, "test-rule", records)
 			if tc.err {
 				if err == nil {

--- a/command/alert/slack/slack.go
+++ b/command/alert/slack/slack.go
@@ -19,11 +19,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"golang.org/x/xerrors"
+
+	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 )
 
 const defaultTextLimit = 6000
@@ -100,7 +102,7 @@ func NewAlertMethod(config *AlertMethodConfig) (alert.Method, error) {
 // of the AlertMethod. If there was an error making the
 // HTTP request, it returns a non-nil error.
 func (s *AlertMethod) Write(ctx context.Context, rule string, records []*alert.Record) error {
-	if records == nil || len(records) < 1 {
+	if len(records) < 1 {
 		return nil
 	}
 	return s.post(ctx, s.buildPayload(rule, records))
@@ -144,7 +146,7 @@ func (s *AlertMethod) buildPayload(rule string, records []*alert.Record) payload
 
 			att.Fields = append(att.Fields, field{
 				Title: f.Key,
-				Value: fmt.Sprintf("%d", f.Count),
+				Value: strconv.Itoa(f.Count),
 				Short: short,
 			})
 		}

--- a/command/alert/sns/sns.go
+++ b/command/alert/sns/sns.go
@@ -23,8 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"golang.org/x/xerrors"
+
+	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 )
 
 // AlertMethodConfig configures where AWS SNS alerts will be
@@ -58,7 +59,7 @@ func NewAlertMethod(config *AlertMethodConfig) (alert.Method, error) {
 	if config.Template == "" {
 		return nil, xerrors.New("field 'output.config.template' must not be empty when using the SNS output method")
 	}
-	tmpl, err := template.New("sns").Funcs(template.FuncMap(sprig.FuncMap())).Parse(config.Template)
+	tmpl, err := template.New("sns").Funcs(sprig.FuncMap()).Parse(config.Template)
 	if err != nil {
 		return nil, xerrors.Errorf("error parsing SNS message template: %w", err)
 	}
@@ -78,7 +79,7 @@ func NewAlertMethod(config *AlertMethodConfig) (alert.Method, error) {
 // Write renders the pre-defined message template and publishes
 // the message to an AWS SNS topic.
 func (a *AlertMethod) Write(ctx context.Context, rule string, records []*alert.Record) error {
-	if records == nil || len(records) < 1 {
+	if len(records) < 1 {
 		return nil
 	}
 	msg, err := a.renderTemplate(rule, records)

--- a/command/alert/sns/sns_test.go
+++ b/command/alert/sns/sns_test.go
@@ -18,6 +18,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 )
 
@@ -165,7 +166,7 @@ func TestAlertMethod_renderTemplate(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			a := &AlertMethod{
-				template: template.Must(template.New("test").Funcs(template.FuncMap(sprig.FuncMap())).Parse(tc.template)),
+				template: template.Must(template.New("test").Funcs(sprig.FuncMap()).Parse(tc.template)),
 			}
 			msg, err := a.renderTemplate("TEST ERROR ALERT", tc.records)
 			if tc.expectErr {

--- a/command/client.go
+++ b/command/client.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	consul "github.com/hashicorp/consul/api"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/config"
 )
 

--- a/command/command.go
+++ b/command/command.go
@@ -22,15 +22,16 @@ import (
 
 	consul "github.com/hashicorp/consul/api"
 	hclog "github.com/hashicorp/go-hclog"
+	"golang.org/x/xerrors"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"github.com/morningconsult/go-elasticsearch-alerts/config"
-	"golang.org/x/xerrors"
 )
 
 // Run starts the daemon running. This function should be
 // called directly within os.Exit() in your main.main()
 // function.
-func Run() int { // nolint: gocyclo, funlen
+func Run() int { //nolint:gocyclo,gocognit
 	logger := hclog.Default()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/command/controller.go
+++ b/command/controller.go
@@ -17,10 +17,11 @@ import (
 	"context"
 	"sync"
 
+	"golang.org/x/xerrors"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"github.com/morningconsult/go-elasticsearch-alerts/command/query"
 	"github.com/morningconsult/go-elasticsearch-alerts/utils/lock"
-	"golang.org/x/xerrors"
 )
 
 type controllerConfig struct {

--- a/command/handlers.go
+++ b/command/handlers.go
@@ -18,6 +18,8 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/xerrors"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert/email"
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert/file"
@@ -25,7 +27,6 @@ import (
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert/sns"
 	"github.com/morningconsult/go-elasticsearch-alerts/command/query"
 	"github.com/morningconsult/go-elasticsearch-alerts/config"
-	"golang.org/x/xerrors"
 )
 
 func buildQueryHandlers(

--- a/command/query/transform.go
+++ b/command/query/transform.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+
 	"github.com/morningconsult/go-elasticsearch-alerts/command/alert"
 	"github.com/morningconsult/go-elasticsearch-alerts/config"
 	"github.com/morningconsult/go-elasticsearch-alerts/utils"
@@ -31,9 +32,11 @@ const hitsDelimiter = "\n----------------------------------------\n"
 // *QueryHandler.bodyField (if any), and an error if there was an error.
 // If process returns a non-nil error, the other returned values will
 // be nil.
-func (q *QueryHandler) process( // nolint: gocyclo
-	respData map[string]interface{},
-) ([]*alert.Record, []map[string]interface{}, error) {
+//
+//nolint:gocognit
+func (q *QueryHandler) process(
+	respData map[string]any,
+) ([]*alert.Record, []map[string]any, error) {
 	if len(q.conditions) != 0 && !config.ConditionsMet(q.logger.Named("conditions"), respData, q.conditions) {
 		return nil, nil, nil
 	}
@@ -41,7 +44,7 @@ func (q *QueryHandler) process( // nolint: gocyclo
 	records := make([]*alert.Record, 0)
 	for _, filter := range q.filters {
 		elems := utils.GetAll(respData, filter)
-		if elems == nil || len(elems) < 1 {
+		if len(elems) < 1 {
 			continue
 		}
 
@@ -85,11 +88,11 @@ func (q *QueryHandler) process( // nolint: gocyclo
 	return records, hits, nil
 }
 
-func (q *QueryHandler) gatherHits(body []interface{}) ([]string, []map[string]interface{}, error) {
+func (q *QueryHandler) gatherHits(body []any) ([]string, []map[string]any, error) {
 	stringifiedHits := make([]string, 0, len(body))
-	hits := make([]map[string]interface{}, 0, len(body))
+	hits := make([]map[string]any, 0, len(body))
 	for _, elem := range body {
-		hit, ok := elem.(map[string]interface{})
+		hit, ok := elem.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -105,10 +108,10 @@ func (q *QueryHandler) gatherHits(body []interface{}) ([]string, []map[string]in
 	return stringifiedHits, hits, nil
 }
 
-func (q *QueryHandler) gatherFields(elems []interface{}) ([]*alert.Field, error) {
+func (q *QueryHandler) gatherFields(elems []any) ([]*alert.Field, error) {
 	fields := make([]*alert.Field, 0, len(elems))
 	for _, elem := range elems {
-		obj, ok := elem.(map[string]interface{})
+		obj, ok := elem.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/command/query/transform_test.go
+++ b/command/query/transform_test.go
@@ -27,7 +27,7 @@ import (
 func TestProcess(t *testing.T) {
 	cases := []struct {
 		name       string
-		input      map[string]interface{}
+		input      map[string]any
 		filters    []string
 		conditions []config.Condition
 		output     []*alert.Record
@@ -36,15 +36,15 @@ func TestProcess(t *testing.T) {
 	}{
 		{
 			name: "one-level",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": json.Number("2"),
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
@@ -73,12 +73,12 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "field-not-map",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
 							"string",
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
@@ -103,15 +103,15 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "zero-count",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": json.Number("0"),
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
@@ -136,36 +136,36 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "two-levels",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": 5,
-								"program": map[string]interface{}{
-									"buckets": []interface{}{
-										map[string]interface{}{
+								"program": map[string]any{
+									"buckets": []any{
+										map[string]any{
 											"key":       "bim",
 											"doc_count": json.Number("2"),
 										},
-										map[string]interface{}{
+										map[string]any{
 											"key":       "baz",
 											"doc_count": json.Number("3"),
 										},
 									},
 								},
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": 3,
-								"program": map[string]interface{}{
-									"buckets": []interface{}{
-										map[string]interface{}{
+								"program": map[string]any{
+									"buckets": []any{
+										map[string]any{
 											"key":       "ayy",
 											"doc_count": json.Number("1"),
 										},
-										map[string]interface{}{
+										map[string]any{
 											"key":       "lmao",
 											"doc_count": json.Number("2"),
 										},
@@ -205,23 +205,23 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "hits-not-array",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": json.Number("2"),
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
 						},
 					},
 				},
-				"hits": map[string]interface{}{
-					"hits": map[string]interface{}{
+				"hits": map[string]any{
+					"hits": map[string]any{
 						"ayy": "lmao",
 					},
 				},
@@ -247,23 +247,23 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "hit-elems-not-maps",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": json.Number("2"),
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
 						},
 					},
 				},
-				"hits": map[string]interface{}{
-					"hits": []interface{}{
+				"hits": map[string]any{
+					"hits": []any{
 						"sadly",
 						"i",
 						"am",
@@ -294,29 +294,29 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "hit-elems-have-no-source",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": json.Number("2"),
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": json.Number("3"),
 							},
 						},
 					},
 				},
-				"hits": map[string]interface{}{
-					"hits": []interface{}{
-						map[string]interface{}{
+				"hits": map[string]any{
+					"hits": []any{
+						map[string]any{
 							"any": "field",
 							"but": "_source!",
 						},
-						map[string]interface{}{
-							"_source": map[string]interface{}{
+						map[string]any{
+							"_source": map[string]any{
 								"ayy": "lmao",
 							},
 						},
@@ -349,16 +349,16 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "hits-only",
-			input: map[string]interface{}{
-				"hits": map[string]interface{}{
-					"hits": []interface{}{
-						map[string]interface{}{
-							"_source": map[string]interface{}{
+			input: map[string]any{
+				"hits": map[string]any{
+					"hits": []any{
+						map[string]any{
+							"_source": map[string]any{
 								"ayy": "lmao",
 							},
 						},
-						map[string]interface{}{
-							"_source": map[string]interface{}{
+						map[string]any{
+							"_source": map[string]any{
 								"yeah": "buddy",
 							},
 						},
@@ -384,9 +384,9 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "no-hits-no-filters",
-			input: map[string]interface{}{
-				"hits": map[string]interface{}{
-					"hits": []interface{}{},
+			input: map[string]any{
+				"hits": map[string]any{
+					"hits": []any{},
 				},
 			},
 			filters: []string{},
@@ -396,21 +396,21 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "conditions-not-met",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": 2,
-								"queue_size": map[string]interface{}{
+								"queue_size": map[string]any{
 									"value": json.Number("10"),
 								},
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": 3,
-								"queue_size": map[string]interface{}{
+								"queue_size": map[string]any{
 									"value": json.Number("20"),
 								},
 							},
@@ -431,21 +431,21 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "conditions-met",
-			input: map[string]interface{}{
-				"aggregations": map[string]interface{}{
-					"hostname": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			input: map[string]any{
+				"aggregations": map[string]any{
+					"hostname": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key":       "foo",
 								"doc_count": 2,
-								"queue_size": map[string]interface{}{
+								"queue_size": map[string]any{
 									"value": json.Number("10"),
 								},
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key":       "bar",
 								"doc_count": 3,
-								"queue_size": map[string]interface{}{
+								"queue_size": map[string]any{
 									"value": json.Number("20"),
 								},
 							},

--- a/config/client.go
+++ b/config/client.go
@@ -16,8 +16,8 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"golang.org/x/xerrors"
@@ -82,19 +82,18 @@ func (c *Config) NewESClient() (*http.Client, error) {
 	}
 
 	// Load CA certificate
-	caCert, err := ioutil.ReadFile(c.Elasticsearch.Client.CACert)
+	caCert, err := os.ReadFile(c.Elasticsearch.Client.CACert)
 	if err != nil {
 		return nil, xerrors.Errorf("error reading CA certificate file: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 
-	tlsConfig := &tls.Config{ // nolint: gosec
+	tlsConfig := &tls.Config{ //nolint:gosec
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 		ServerName:   c.Elasticsearch.Client.ServerName,
 	}
-	tlsConfig.BuildNameToCertificate()
 	client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	return client, nil
 }

--- a/config/conditions.go
+++ b/config/conditions.go
@@ -43,7 +43,7 @@ const (
 
 // Condition is an optional parameter that can be used to limit
 // when alerts are triggered.
-type Condition map[string]interface{}
+type Condition map[string]any
 
 func (c Condition) field() string {
 	return c[keyField].(string)
@@ -158,7 +158,7 @@ func (c Condition) validateMultiOperators() []error {
 }
 
 // ConditionsMet returns true if the response JSON meets the given conditions.
-func ConditionsMet(logger hclog.Logger, resp map[string]interface{}, conditions []Condition) bool {
+func ConditionsMet(logger hclog.Logger, resp map[string]any, conditions []Condition) bool {
 	for _, condition := range conditions {
 		matches := utils.GetAll(resp, condition.field())
 
@@ -181,7 +181,7 @@ func ConditionsMet(logger hclog.Logger, resp map[string]interface{}, conditions 
 	return true
 }
 
-func allSatisfied(logger hclog.Logger, matches []interface{}, condition Condition) bool {
+func allSatisfied(logger hclog.Logger, matches []any, condition Condition) bool {
 	for _, match := range matches {
 		sat := satisfied(logger, match, condition)
 		if !sat {
@@ -192,7 +192,7 @@ func allSatisfied(logger hclog.Logger, matches []interface{}, condition Conditio
 	return true
 }
 
-func anySatisfied(logger hclog.Logger, matches []interface{}, condition Condition) bool {
+func anySatisfied(logger hclog.Logger, matches []any, condition Condition) bool {
 	for _, match := range matches {
 		sat := satisfied(logger, match, condition)
 		if sat {
@@ -203,7 +203,7 @@ func anySatisfied(logger hclog.Logger, matches []interface{}, condition Conditio
 	return false
 }
 
-func noneSatisfied(logger hclog.Logger, matches []interface{}, condition Condition) bool {
+func noneSatisfied(logger hclog.Logger, matches []any, condition Condition) bool {
 	for _, match := range matches {
 		sat := satisfied(logger, match, condition)
 		if sat {
@@ -214,7 +214,7 @@ func noneSatisfied(logger hclog.Logger, matches []interface{}, condition Conditi
 	return true
 }
 
-func satisfied(logger hclog.Logger, match interface{}, condition Condition) bool {
+func satisfied(logger hclog.Logger, match any, condition Condition) bool {
 	switch v := match.(type) {
 	case string:
 		return stringSatisfied(v, condition)
@@ -223,7 +223,7 @@ func satisfied(logger hclog.Logger, match interface{}, condition Condition) bool
 	case bool:
 		return boolSatisfied(v, condition)
 	default:
-		fields := make([]interface{}, 0, 4)
+		fields := make([]any, 0, 4)
 		if f, ok := condition[keyField].(string); ok {
 			fields = append(fields, "field", f)
 		}
@@ -234,13 +234,13 @@ func satisfied(logger hclog.Logger, match interface{}, condition Condition) bool
 			fields = append(fields, "value", match)
 		}
 
-		logger.Error("Value of field in Elasticsearch response is not a string, number, or boolean. Ignoring condition for this value", fields...) // nolint: lll
+		logger.Error("Value of field in Elasticsearch response is not a string, number, or boolean. Ignoring condition for this value", fields...) //nolint:lll
 
 		return true
 	}
 }
 
-func numberSatisfied(k json.Number, condition Condition) bool { // nolint: gocyclo
+func numberSatisfied(k json.Number, condition Condition) bool { //nolint:gocyclo,gocognit
 	d := decimal.RequireFromString(k.String())
 
 	dec := decimal.RequireFromString

--- a/config/conditions_test.go
+++ b/config/conditions_test.go
@@ -91,7 +91,7 @@ func TestCondition_validate(t *testing.T) {
 				"ge":         "asdf",
 				"gt":         10, // not a json.Number
 				"le":         true,
-				"lt":         map[string]interface{}{"ayy": "lmao"},
+				"lt":         map[string]any{"ayy": "lmao"},
 			},
 			expectErr: `4 errors occurred:
 	* value of operator 'le' should be a number
@@ -109,7 +109,7 @@ func TestCondition_validate(t *testing.T) {
 				"ge":         "asdf",
 				"gt":         10, // not a json.Number
 				"le":         true,
-				"lt":         map[string]interface{}{"ayy": "lmao"},
+				"lt":         map[string]any{"ayy": "lmao"},
 				"eq":         true, // not a json.Number or string
 				"ne":         100,  // not a json.Number or string
 			},
@@ -355,7 +355,7 @@ func TestConditionsMet(t *testing.T) {
 			dec := json.NewDecoder(buf)
 			dec.UseNumber()
 
-			var res map[string]interface{}
+			var res map[string]any
 			if err := dec.Decode(&res); err != nil {
 				t.Fatal(err)
 			}

--- a/config/parse.go
+++ b/config/parse.go
@@ -43,14 +43,14 @@ type OutputConfig struct {
 	// The content of this field is specific to the output type.
 	// Please refer to the README for more detailed information
 	// on this field
-	Config map[string]interface{} `json:"config"`
+	Config map[string]any `json:"config"`
 }
 
 func (o OutputConfig) validate() error {
 	if o.Type == "" {
 		return errors.New("all outputs must have a type specified ('output.type')")
 	}
-	if o.Config == nil || len(o.Config) < 1 {
+	if len(o.Config) < 1 {
 		return errors.New("all outputs must have a config field ('output.config')")
 	}
 	return nil
@@ -100,11 +100,11 @@ type RuleConfig struct {
 	// alert should send when querying Elasticsearch. This
 	// value should come from the 'body' field of the
 	// rule configuration file
-	ElasticsearchBodyRaw interface{} `json:"body"`
+	ElasticsearchBodyRaw any `json:"body"`
 
 	// ElasticsearchBody is the typed query that this alert
 	// will send when querying Elasticsearch
-	ElasticsearchBody map[string]interface{} `json:"-"`
+	ElasticsearchBody map[string]any `json:"-"`
 
 	// Filters are the additional fields on which the application
 	// should group query responses before sending alerts. This
@@ -120,7 +120,7 @@ type RuleConfig struct {
 	Conditions []Condition
 }
 
-func (rule *RuleConfig) validate() error { // nolint: gocyclo
+func (rule *RuleConfig) validate() error { //nolint:gocyclo,gocognit
 	if rule.Name == "" {
 		return errors.New("no 'name' field found")
 	}
@@ -251,7 +251,7 @@ func ParseConfig() (*Config, error) {
 	}
 	if cfg.Distributed {
 		if cfg.Consul == nil {
-			return nil, xerrors.Errorf("no field 'consul' found in main configuration file %s (required when 'distributed' is true)", configFile) // nolint: lll
+			return nil, xerrors.Errorf("no field 'consul' found in main configuration file %s (required when 'distributed' is true)", configFile) //nolint:lll
 		}
 		if err = cfg.Consul.validate(); err != nil {
 			return nil, xerrors.Errorf("error in main configuration file %s: %v", configFile, err)
@@ -320,12 +320,12 @@ func ParseRules() ([]RuleConfig, error) {
 	return rules, nil
 }
 
-func parseBody(v interface{}) (map[string]interface{}, error) {
+func parseBody(v any) (map[string]any, error) {
 	switch b := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return b, nil
 	case string:
-		var body map[string]interface{}
+		var body map[string]any
 		if err := json.NewDecoder(bytes.NewBufferString(b)).Decode(&body); err != nil {
 			return nil, xerrors.Errorf("error JSON-decoding 'body' field: %v", err)
 		}

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -15,7 +15,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -125,16 +124,14 @@ func TestParseConfig_MainConfig(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv(envConfigFile, tc.path)
-			defer os.Unsetenv(envConfigFile)
+			t.Setenv(envConfigFile, tc.path)
 
 			if tc.name == "success" {
-				os.Setenv(envRulesDir, "testdata/rules-main")
-				defer os.Unsetenv(envRulesDir)
+				t.Setenv(envRulesDir, "testdata/rules-main")
 			}
 
 			if tc.name != "homedir-error" && tc.name != "file-doesnt-exist" {
-				if err := ioutil.WriteFile(tc.path, []byte(tc.data), 0o666); err != nil {
+				if err := os.WriteFile(tc.path, []byte(tc.data), 0o666); err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(tc.path)
@@ -550,12 +547,11 @@ func TestParseConfig_Rules(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv(envRulesDir, tc.path)
-			defer os.Unsetenv(envRulesDir)
+			t.Setenv(envRulesDir, tc.path)
 
 			for _, file := range tc.files {
 				fname := filepath.Join(tc.path, file.filename)
-				if err := ioutil.WriteFile(fname, []byte(file.data), 0o666); err != nil {
+				if err := os.WriteFile(fname, []byte(file.data), 0o666); err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(fname)
@@ -579,7 +575,7 @@ func TestParseConfig_Rules(t *testing.T) {
 			}
 
 			for i, file := range tc.files {
-				var contents map[string]interface{}
+				var contents map[string]any
 				if err := json.Unmarshal([]byte(file.data), &contents); err != nil {
 					t.Fatal(err)
 				}
@@ -630,7 +626,7 @@ func TestParseConfig_Rules(t *testing.T) {
 					}
 				}
 
-				body, ok := contents["body"].(map[string]interface{})
+				body, ok := contents["body"].(map[string]any)
 				if !ok {
 					continue
 				}
@@ -640,7 +636,7 @@ func TestParseConfig_Rules(t *testing.T) {
 						rules[i].ElasticsearchBody, body)
 				}
 
-				outputs, ok := contents["outputs"].([]interface{})
+				outputs, ok := contents["outputs"].([]any)
 				if !ok {
 					continue
 				}

--- a/utils/traverse_test.go
+++ b/utils/traverse_test.go
@@ -19,138 +19,26 @@ import (
 	"testing"
 )
 
-func TestGet(t *testing.T) {
-	cases := []struct {
-		name   string
-		json   map[string]interface{}
-		path   string
-		output interface{}
-	}{
-		{
-			"map",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"my": map[string]interface{}{
-							"old": "friend",
-						},
-					},
-				},
-			},
-			"hello.darkness.my",
-			map[string]interface{}{
-				"old": "friend",
-			},
-		},
-		{
-			"array",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"my": []interface{}{
-							map[string]interface{}{
-								"old": "friend",
-							},
-							map[string]interface{}{
-								"ive": "come",
-							},
-							map[string]interface{}{
-								"to": "talk",
-							},
-						},
-					},
-				},
-			},
-			"hello.darkness.my",
-			[]interface{}{
-				map[string]interface{}{
-					"old": "friend",
-				},
-				map[string]interface{}{
-					"ive": "come",
-				},
-				map[string]interface{}{
-					"to": "talk",
-				},
-			},
-		},
-		{
-			"within-array",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"my": []interface{}{
-							map[string]interface{}{
-								"old": "friend",
-							},
-							map[string]interface{}{
-								"ive": "come",
-							},
-							map[string]interface{}{
-								"to": "talk",
-							},
-						},
-					},
-				},
-			},
-			"hello.darkness.my[2].to",
-			"talk",
-		},
-		{
-			"non-int-index",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"my": []interface{}{
-							map[string]interface{}{
-								"old": "friend",
-							},
-							map[string]interface{}{
-								"ive": "come",
-							},
-							map[string]interface{}{
-								"to": "talk",
-							},
-						},
-					},
-				},
-			},
-			"hello.darkness.my[a].to",
-			nil,
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			out := Get(tc.json, tc.path)
-			if !reflect.DeepEqual(out, tc.output) {
-				t.Fatalf("Got:\n%+v\n\nExpected:\n%+v", out, tc.output)
-			}
-		})
-	}
-}
-
 func TestGetAll(t *testing.T) {
 	cases := []struct {
 		name   string
-		json   map[string]interface{}
+		json   map[string]any
 		path   string
-		output interface{}
+		output any
 	}{
 		{
 			"not-nested",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"my": []interface{}{
-							map[string]interface{}{
+			map[string]any{
+				"hello": map[string]any{
+					"darkness": map[string]any{
+						"my": []any{
+							map[string]any{
 								"old": "friend",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"ive": "come",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"to": "talk",
 							},
 						},
@@ -158,48 +46,48 @@ func TestGetAll(t *testing.T) {
 				},
 			},
 			"hello.darkness.my",
-			[]interface{}{
-				map[string]interface{}{
+			[]any{
+				map[string]any{
 					"old": "friend",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"ive": "come",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"to": "talk",
 				},
 			},
 		},
 		{
 			"nested",
-			map[string]interface{}{
-				"hello": map[string]interface{}{
-					"darkness": map[string]interface{}{
-						"buckets": []interface{}{
-							map[string]interface{}{
+			map[string]any{
+				"hello": map[string]any{
+					"darkness": map[string]any{
+						"buckets": []any{
+							map[string]any{
 								"key": "old",
-								"ayy": map[string]interface{}{
-									"buckets": []interface{}{
-										map[string]interface{}{
+								"ayy": map[string]any{
+									"buckets": []any{
+										map[string]any{
 											"key":   "greg",
 											"hello": "world",
 										},
-										map[string]interface{}{
+										map[string]any{
 											"key":   "friend",
 											"hello": "darkness",
 										},
 									},
 								},
 							},
-							map[string]interface{}{
+							map[string]any{
 								"key": "yesterday",
-								"ayy": map[string]interface{}{
-									"buckets": []interface{}{
-										map[string]interface{}{
+								"ayy": map[string]any{
+									"buckets": []any{
+										map[string]any{
 											"key": "troubles",
 											"far": "away",
 										},
-										map[string]interface{}{
+										map[string]any{
 											"key": "here",
 											"to":  "stay",
 										},
@@ -211,20 +99,20 @@ func TestGetAll(t *testing.T) {
 				},
 			},
 			"hello.darkness.buckets.ayy.buckets",
-			[]interface{}{
-				map[string]interface{}{
+			[]any{
+				map[string]any{
 					"key":   "old - greg",
 					"hello": "world",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key":   "old - friend",
 					"hello": "darkness",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key": "yesterday - troubles",
 					"far": "away",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key": "yesterday - here",
 					"to":  "stay",
 				},
@@ -243,86 +131,51 @@ func TestGetAll(t *testing.T) {
 	}
 }
 
-func ExampleGet() {
-	jsonData := map[string]interface{}{
-		"hello": map[string]interface{}{
-			"world": []interface{}{
-				map[string]interface{}{
-					"foo": "example-1",
-					"bar": map[string]interface{}{
-						"bim": "baz",
-					},
-				},
-				map[string]interface{}{
-					"foo": "example-2",
-					"bar": map[string]interface{}{
-						"ping": "pong",
-					},
-				},
-			},
-		},
-	}
-
-	v := Get(jsonData, "hello.world.bar")
-	fmt.Printf("%v\n", v)
-
-	v = Get(jsonData, "hello.world[0].foo")
-	fmt.Printf("%v\n", v)
-
-	v = Get(jsonData, "hello.world[0].bar")
-	fmt.Printf("%#v\n", v)
-
-	// Output:
-	// <nil>
-	// example-1
-	// map[string]interface {}{"bim":"baz"}
-}
-
 func ExampleGetAll() {
-	jsonData := map[string]interface{}{
-		"hits": map[string]interface{}{
-			"hits": []interface{}{
-				map[string]interface{}{
-					"_source": map[string]interface{}{
+	jsonData := map[string]any{
+		"hits": map[string]any{
+			"hits": []any{
+				map[string]any{
+					"_source": map[string]any{
 						"foo": "bar",
 					},
 				},
-				map[string]interface{}{
-					"_source": map[string]interface{}{
+				map[string]any{
+					"_source": map[string]any{
 						"bim": "baz",
 					},
 				},
 			},
 		},
-		"aggregations": map[string]interface{}{
-			"hostname": map[string]interface{}{
-				"buckets": []interface{}{
-					map[string]interface{}{
+		"aggregations": map[string]any{
+			"hostname": map[string]any{
+				"buckets": []any{
+					map[string]any{
 						"key":   "foo",
 						"count": 10,
-						"program": map[string]interface{}{
-							"buckets": []interface{}{
-								map[string]interface{}{
+						"program": map[string]any{
+							"buckets": []any{
+								map[string]any{
 									"key":   "bar",
 									"count": 3,
 								},
-								map[string]interface{}{
+								map[string]any{
 									"key":   "bim",
 									"count": 7,
 								},
 							},
 						},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key":   "hello",
 						"count": 6,
-						"program": map[string]interface{}{
-							"buckets": []interface{}{
-								map[string]interface{}{
+						"program": map[string]any{
+							"buckets": []any{
+								map[string]any{
 									"key":   "world",
 									"count": 2,
 								},
-								map[string]interface{}{
+								map[string]any{
 									"key":   "darkness",
 									"count": 4,
 								},
@@ -334,33 +187,33 @@ func ExampleGetAll() {
 		},
 	}
 
-	expected1 := []interface{}{
-		map[string]interface{}{
+	expected1 := []any{
+		map[string]any{
 			"key":   "foo",
 			"count": 10,
-			"program": map[string]interface{}{
-				"buckets": []interface{}{
-					map[string]interface{}{
+			"program": map[string]any{
+				"buckets": []any{
+					map[string]any{
 						"key":   "bar",
 						"count": 3,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key":   "bim",
 						"count": 7,
 					},
 				},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":   "hello",
 			"count": 6,
-			"program": map[string]interface{}{
-				"buckets": []interface{}{
-					map[string]interface{}{
+			"program": map[string]any{
+				"buckets": []any{
+					map[string]any{
 						"key":   "world",
 						"count": 2,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key":   "darkness",
 						"count": 4,
 					},
@@ -369,20 +222,20 @@ func ExampleGetAll() {
 		},
 	}
 
-	expected2 := []interface{}{
-		map[string]interface{}{
+	expected2 := []any{
+		map[string]any{
 			"key":   "foo - bar",
 			"count": 3,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":   "foo - bim",
 			"count": 7,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":   "hello - world",
 			"count": 2,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":   "hello - darkness",
 			"count": 4,
 		},


### PR DESCRIPTION
I'm still keeping the rule to only lint new issues on, because there are a handful of high-complexity functions that I don't want to address at the moment, but otherwise we're basically clean.

Most of the changes are self evident, and many of them were applied automatically, but for the handful that aren't:

- `utils.Get` was only used once, and is WAY less code to just inline a proper struct type for that one case. `utils.GetAll` should maybe also be removed, but would take more work than this change warrants.
- The docs for `tlsConfig.BuildNameToCertificate` seems to imply that we simply don't need to call it at all. It's not an auto-fix, but that seems like the obvious fix.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.