### PR TITLE
refactor: reduce cognitive complexity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 version: "2"
 issues:
-  new: true # TODO: Fix issues and remove this config
   max-same-issues: 0
 
 linters:

--- a/command/command.go
+++ b/command/command.go
@@ -125,6 +125,7 @@ func Run() int { //nolint:gocyclo,gocognit
 	}
 }
 
+//nolint:gocognit
 func handleDistOp(
 	ctx context.Context,
 	cfg config.ConsulConfig,

--- a/command/handlers.go
+++ b/command/handlers.go
@@ -35,16 +35,14 @@ func buildQueryHandlers(
 	esClient *http.Client,
 	logger hclog.Logger,
 ) ([]*query.QueryHandler, error) {
-	if len(rules) < 1 {
+	switch {
+	case len(rules) < 1:
 		return nil, xerrors.New("at least one rule must be provided")
-	}
-	if logger == nil {
+	case logger == nil:
 		return nil, xerrors.New("no logger provided")
-	}
-	if esClient == nil {
+	case esClient == nil:
 		return nil, xerrors.New("no HTTP client provided")
-	}
-	if esURL == "" {
+	case esURL == "":
 		return nil, xerrors.New("no URL provided")
 	}
 


### PR DESCRIPTION
This removes the final set of golangci-lint issues that was barring us from only linting against "new" issues.

I did unfortunately add one nolint directive, but the function itself is a deep part of a concurrent process, and as far as I can tell not covered by tests. So I figured it's probably safer to leave it alone, especially if the options I'm considering would potentially also be changes in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.