### PR TITLE
ci: group dependencies into monthly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - dbellinghoven
-  labels:
-  - dependencies
-  ignore:
-  - dependency-name: github.com/google/go-cmp
-    versions:
-    - 0.5.4
+    interval: monthly
+  groups:
+    dependencies:
+      patterns: ["*"]


### PR DESCRIPTION
The current behavior is, every day at 10:00, we get a PR for every update. For this sort of tool, that's pretty unnecessary.

This groups all Go version updates into a single PR, once per month. The reason we can be comfortable with this cadence is that dependabot treats version updates separately from security updates, and because there's no urgency in non-security related updates, a monthly cadence is a lot more on pace for our level of active maintenance.

Also clean up the properties we don't need to configure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.