### PR TITLE
feat: remove compatibility header

### DIFF
--- a/command/query/job.go
+++ b/command/query/job.go
@@ -202,10 +202,6 @@ func validateConfig(config *QueryHandlerConfig) error {
 	return allErrors.ErrorOrNil()
 }
 
-// compatibilityHeader is the header to enable REST API compatibility.
-// https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html
-const compatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=7"
-
 func buildHTTPRequestFunc() (func(context.Context, string, string, io.Reader) (*http.Request, error), error) {
 	username := os.Getenv(envESBasicAuthUsername)
 	password := os.Getenv(envESBasicAuthPassword)
@@ -225,10 +221,6 @@ func buildHTTPRequestFunc() (func(context.Context, string, string, io.Reader) (*
 		}
 		if username != "" {
 			req.SetBasicAuth(username, password)
-		}
-		req.Header.Set("Accept", compatibilityHeader)
-		if data != nil {
-			req.Header.Set("Content-Type", compatibilityHeader)
 		}
 		return req, nil
 	}


### PR DESCRIPTION
BREAKING CHANGE: When running against Elasticsearch 9, you can only set the compatibility header to ES 8, not 7. To avoid having to set this within the application and update it for different target Elastsicsearch clusters, this PR removes the header entirely. It is up to the user to apply this header using a proxy or other means within their network setup.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.