### PR TITLE
fix: need to set content type header

### DIFF
--- a/command/query/job.go
+++ b/command/query/job.go
@@ -219,6 +219,9 @@ func buildHTTPRequestFunc() (func(context.Context, string, string, io.Reader) (*
 		if err != nil {
 			return nil, xerrors.Errorf("error creating new HTTP request instance: %v", err)
 		}
+		if data != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 		if username != "" {
 			req.SetBasicAuth(username, password)
 		}

--- a/command/query/job_test.go
+++ b/command/query/job_test.go
@@ -233,6 +233,11 @@ func TestPutTemplate(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.Method {
 				case "PUT", "POST":
+					contentType := r.Header.Get("Content-Type")
+					if contentType != "application/json" {
+						http.Error(w, fmt.Sprintf("unexpected Content-Type header value (got %q, expected %q)", contentType, "application/json"), http.StatusBadRequest)
+						return
+					}
 					if tc.status-200 > 3 {
 						http.Error(w, http.StatusText(tc.status), tc.status)
 						return
@@ -258,7 +263,7 @@ func TestPutTemplate(t *testing.T) {
 					http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 				}
 			}))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			u := ts.URL
 			if tc.name == badURL {


### PR DESCRIPTION
Otherwise Elasticsearch rejects it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.